### PR TITLE
Fixed a typo when creating the virtual environment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ cd plant-tracker
 Create a virtual environment to install dependencies in and activate it:
 
 ```sh
-$ python -m venv /venv/
+$ python -m venv ./venv/
 $ venv/Scripts/activate.bat
 ```
 


### PR DESCRIPTION
Added a period before the name of the directory to trying to create the virtual environment in the root directory.